### PR TITLE
Refactor Invoke method to allow subsequent function invocations after failures

### DIFF
--- a/pkg/openfaas/cacher.go
+++ b/pkg/openfaas/cacher.go
@@ -75,7 +75,6 @@ func (c *Controller) Invoke(topic string, invocation *types2.OpenFaaSInvocation)
 		return nil
 	}
 
-	var invocationErr error
 	for _, fn := range functions {
 		// Log the start of processing each function
 		c.logJSON("info", "Processing function", map[string]interface{}{
@@ -193,14 +192,11 @@ func (c *Controller) Invoke(topic string, invocation *types2.OpenFaaSInvocation)
 					"syncError":  err,
 					"asyncError": lastAsyncErr,
 				})
-				// Record first failure so caller can NACK/requeue; continue invoking
-				// remaining functions so one function's failure does not starve others.
-				if invocationErr == nil {
-					invocationErr = fmt.Errorf("function %q failed sync and async retries: sync error: %w; async error: %v", fn, err, lastAsyncErr)
-				}
 			}
 
-			// Move on to the next registered function.
+			// Deliberately do not propagate the failure: NACKing would requeue the
+			// message and cause duplicate invocations for the functions that already
+			// succeeded on this delivery. Continue to the next function instead.
 			continue
 		}
 
@@ -213,7 +209,7 @@ func (c *Controller) Invoke(topic string, invocation *types2.OpenFaaSInvocation)
 			"contentType": invocation.ContentType,
 		})
 	}
-	return invocationErr
+	return nil
 }
 func (c *Controller) applyAllFilters(cachedFilter string, message *[]byte) bool {
 	var payload map[string]interface{}

--- a/pkg/openfaas/cacher.go
+++ b/pkg/openfaas/cacher.go
@@ -158,6 +158,7 @@ func (c *Controller) Invoke(topic string, invocation *types2.OpenFaaSInvocation)
 			})
 
 			// Async fallback with retries
+			asyncSucceeded := false
 			for i := 0; i < 3; i++ {
 				c.logJSON("info", "Attempting async invocation", map[string]interface{}{
 					"function": fn,
@@ -179,14 +180,20 @@ func (c *Controller) Invoke(topic string, invocation *types2.OpenFaaSInvocation)
 					"function": fn,
 					"status":   asyncStatusCode,
 				})
-				return nil
+				asyncSucceeded = true
+				break
 			}
 
-			c.logJSON("error", "Async invocation failed after retries", map[string]interface{}{
-				"function": fn,
-				"error":    err,
-			})
-			return err
+			if !asyncSucceeded {
+				c.logJSON("error", "Async invocation failed after retries", map[string]interface{}{
+					"function": fn,
+					"error":    err,
+				})
+			}
+
+			// Move on to the next registered function instead of returning,
+			// so one function's failure does not starve others subscribed to the same topic.
+			continue
 		}
 
 		c.logJSON("info", "Invocation succeeded", map[string]interface{}{

--- a/pkg/openfaas/cacher.go
+++ b/pkg/openfaas/cacher.go
@@ -75,6 +75,7 @@ func (c *Controller) Invoke(topic string, invocation *types2.OpenFaaSInvocation)
 		return nil
 	}
 
+	var invocationErr error
 	for _, fn := range functions {
 		// Log the start of processing each function
 		c.logJSON("info", "Processing function", map[string]interface{}{
@@ -159,6 +160,7 @@ func (c *Controller) Invoke(topic string, invocation *types2.OpenFaaSInvocation)
 
 			// Async fallback with retries
 			asyncSucceeded := false
+			var lastAsyncErr error
 			for i := 0; i < 3; i++ {
 				c.logJSON("info", "Attempting async invocation", map[string]interface{}{
 					"function": fn,
@@ -167,6 +169,7 @@ func (c *Controller) Invoke(topic string, invocation *types2.OpenFaaSInvocation)
 
 				_, asyncStatusCode, asyncErr := c.client.InvokeAsync(context.Background(), fn, invocation)
 				if asyncErr != nil {
+					lastAsyncErr = asyncErr
 					c.logJSON("error", "Async invocation failed, retrying...", map[string]interface{}{
 						"function": fn,
 						"error":    asyncErr,
@@ -186,13 +189,18 @@ func (c *Controller) Invoke(topic string, invocation *types2.OpenFaaSInvocation)
 
 			if !asyncSucceeded {
 				c.logJSON("error", "Async invocation failed after retries", map[string]interface{}{
-					"function": fn,
-					"error":    err,
+					"function":   fn,
+					"syncError":  err,
+					"asyncError": lastAsyncErr,
 				})
+				// Record first failure so caller can NACK/requeue; continue invoking
+				// remaining functions so one function's failure does not starve others.
+				if invocationErr == nil {
+					invocationErr = fmt.Errorf("function %q failed sync and async retries: sync error: %w; async error: %v", fn, err, lastAsyncErr)
+				}
 			}
 
-			// Move on to the next registered function instead of returning,
-			// so one function's failure does not starve others subscribed to the same topic.
+			// Move on to the next registered function.
 			continue
 		}
 
@@ -205,7 +213,7 @@ func (c *Controller) Invoke(topic string, invocation *types2.OpenFaaSInvocation)
 			"contentType": invocation.ContentType,
 		})
 	}
-	return nil
+	return invocationErr
 }
 func (c *Controller) applyAllFilters(cachedFilter string, message *[]byte) bool {
 	var payload map[string]interface{}

--- a/pkg/openfaas/cacher_test.go
+++ b/pkg/openfaas/cacher_test.go
@@ -228,7 +228,7 @@ func TestCacher_Invoke(t *testing.T) {
 		clientMock.AssertExpectations(t)
 	})
 
-	t.Run("Should continue invoking remaining functions when one function's sync+async both fail", func(t *testing.T) {
+	t.Run("Should continue invoking remaining functions and return error when sync+async fail", func(t *testing.T) {
 		clientMock := new(MockOpenFaaSClient)
 		clientMock.On("InvokeSync", mock.Anything, mock.Anything, mock.Anything).Return([]byte{}, 500, errors.New("failed"))
 		clientMock.On("InvokeAsync", mock.Anything, mock.Anything, mock.Anything).Return(false, 500, errors.New("async failed"))
@@ -237,10 +237,11 @@ func TestCacher_Invoke(t *testing.T) {
 
 		err := cacher.Invoke(TOPIC, makeInvocation(TOPIC))
 
-		assert.NoError(t, err, "one function's failure must not short-circuit the loop")
-		// 3 functions × 3 sync retries each
+		// Must return an error so the caller in rabbitmq/exchange.go NACKs/requeues.
+		assert.Error(t, err, "failed sync+async retries must be reported so the delivery is requeued")
+		// 3 functions × 3 sync retries each — no short-circuit despite failures.
 		clientMock.AssertNumberOfCalls(t, "InvokeSync", 9)
-		// 3 functions × 3 async retries each
+		// 3 functions × 3 async retries each.
 		clientMock.AssertNumberOfCalls(t, "InvokeAsync", 9)
 	})
 

--- a/pkg/openfaas/cacher_test.go
+++ b/pkg/openfaas/cacher_test.go
@@ -228,7 +228,7 @@ func TestCacher_Invoke(t *testing.T) {
 		clientMock.AssertExpectations(t)
 	})
 
-	t.Run("Should continue invoking remaining functions and return error when sync+async fail", func(t *testing.T) {
+	t.Run("Should attempt every function and not NACK when sync+async both fail", func(t *testing.T) {
 		clientMock := new(MockOpenFaaSClient)
 		clientMock.On("InvokeSync", mock.Anything, mock.Anything, mock.Anything).Return([]byte{}, 500, errors.New("failed"))
 		clientMock.On("InvokeAsync", mock.Anything, mock.Anything, mock.Anything).Return(false, 500, errors.New("async failed"))
@@ -237,8 +237,9 @@ func TestCacher_Invoke(t *testing.T) {
 
 		err := cacher.Invoke(TOPIC, makeInvocation(TOPIC))
 
-		// Must return an error so the caller in rabbitmq/exchange.go NACKs/requeues.
-		assert.Error(t, err, "failed sync+async retries must be reported so the delivery is requeued")
+		// Must return nil so the delivery is ACKed — NACKing would requeue and cause
+		// duplicate invocations for functions that already succeeded on this delivery.
+		assert.NoError(t, err, "do not NACK on per-function failure — duplicates would be worse than loss")
 		// 3 functions × 3 sync retries each — no short-circuit despite failures.
 		clientMock.AssertNumberOfCalls(t, "InvokeSync", 9)
 		// 3 functions × 3 async retries each.

--- a/pkg/openfaas/cacher_test.go
+++ b/pkg/openfaas/cacher_test.go
@@ -228,7 +228,7 @@ func TestCacher_Invoke(t *testing.T) {
 		clientMock.AssertExpectations(t)
 	})
 
-	t.Run("Should abort invocation of functions on receiving first error further returning it", func(t *testing.T) {
+	t.Run("Should continue invoking remaining functions when one function's sync+async both fail", func(t *testing.T) {
 		clientMock := new(MockOpenFaaSClient)
 		clientMock.On("InvokeSync", mock.Anything, mock.Anything, mock.Anything).Return([]byte{}, 500, errors.New("failed"))
 		clientMock.On("InvokeAsync", mock.Anything, mock.Anything, mock.Anything).Return(false, 500, errors.New("async failed"))
@@ -237,7 +237,28 @@ func TestCacher_Invoke(t *testing.T) {
 
 		err := cacher.Invoke(TOPIC, makeInvocation(TOPIC))
 
-		assert.Error(t, err, "failed")
+		assert.NoError(t, err, "one function's failure must not short-circuit the loop")
+		// 3 functions × 3 sync retries each
+		clientMock.AssertNumberOfCalls(t, "InvokeSync", 9)
+		// 3 functions × 3 async retries each
+		clientMock.AssertNumberOfCalls(t, "InvokeAsync", 9)
+	})
+
+	t.Run("Should continue invoking remaining functions after async fallback succeeds for one", func(t *testing.T) {
+		clientMock := new(MockOpenFaaSClient)
+		clientMock.On("InvokeSync", mock.Anything, "billing", mock.Anything).Return([]byte{}, 500, errors.New("sync failed"))
+		clientMock.On("InvokeAsync", mock.Anything, "billing", mock.Anything).Return(true, 202, nil)
+		clientMock.On("InvokeSync", mock.Anything, "secret", mock.Anything).Return([]byte{}, 200, nil)
+		clientMock.On("InvokeSync", mock.Anything, "transport", mock.Anything).Return([]byte{}, 200, nil)
+
+		cacher := NewController(nil, clientMock, cacheMock)
+
+		err := cacher.Invoke(TOPIC, makeInvocation(TOPIC))
+
+		assert.NoError(t, err, "async success for one function must not short-circuit the loop")
+		// billing: 3 sync retries + 1 async; secret: 1 sync; transport: 1 sync
+		clientMock.AssertNumberOfCalls(t, "InvokeSync", 5)
+		clientMock.AssertNumberOfCalls(t, "InvokeAsync", 1)
 	})
 
 	t.Run("Should not invoke if there is no function for specified Topic", func(t *testing.T) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * System no longer stops processing other subscribers when an async invocation for one function fails; delivery continues to remaining functions.
  * Async retry behavior now records whether an async attempt succeeded and reports final async failures only if no async attempt succeeded.

* **Tests**
  * Updated tests to verify continued invocation across multiple functions and successful async fallback handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->